### PR TITLE
feat: obtain environment variables from ssm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-NETWORK_NAME=mainnet
-INFURA_API_KEY=somekey
-WHITELISTED_ISSUERS=gov.sg,openattestation.com
+/serverless/api-verify-gov-sg/NETWORK_NAME=mainnet
+/serverless/api-verify-gov-sg/INFURA_API_KEY=somekey
+/serverless/api-verify-gov-sg/WHITELISTED_ISSUERS=gov.sg,openattestation.com

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,8 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "import/prefer-default-export": "off",
-    "arrow-body-style": "off"
+    "arrow-body-style": "off",
+    "no-template-curly-in-string": "off"
   },
   "ignorePatterns": ["*.config.js"],
   "settings": {

--- a/README.md
+++ b/README.md
@@ -8,17 +8,45 @@ NodeJS `lts/fermium (v.14.15.0)`. If you're using [nvm](https://github.com/nvm-s
 
 ## Getting Started
 
-To run locally:
+### 1. Ensure environment variables are set
+
+To run locally, ensure the required environment variables are set in `.env`. Refer to [.env.example](.env.example):
+
+```text
+/serverless/api-verify-gov-sg/NETWORK_NAME=mainnet
+/serverless/api-verify-gov-sg/INFURA_API_KEY=somekey
+/serverless/api-verify-gov-sg/WHITELISTED_ISSUERS=gov.sg,openattestation.com
+```
+
+### 2. Run a local instance
 
 ```bash
 npm i
 npm run dev
 ```
 
-Make a POST request with curl:
+### 3. Make a POST request with curl:
 
 ```bash
 curl --location --request POST 'localhost:3000/dev/verify' \
 --header 'Content-Type: application/json' \
 --data-binary '@./fixtures/pdt_pcr_notarized_with_nric_wrapped.json'
+```
+
+**Sample response**:
+
+```json
+{
+  "isValid": true,
+  "fragments": [
+    {
+      "type": "DOCUMENT_INTEGRITY",
+      "name": "OpenAttestationHash",
+      "data": true,
+      "status": "VALID"
+    }
+    // Other fragments...
+  ],
+  "diagnostics": []
+}
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10991,6 +10991,12 @@
         "ws": "^7.5.5"
       }
     },
+    "serverless-offline-ssm": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-offline-ssm/-/serverless-offline-ssm-5.2.0.tgz",
+      "integrity": "sha512-AKNqgc0up5XUkZva3SeIIPss3DucBBOglJ5rIo1qJk14j4ZuT/6Pg99l0newxH5aOniBYE1P9YrUAjK50b6BjA==",
+      "dev": true
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "serverless": "^2.23.0",
     "serverless-esbuild": "^1.22.0",
     "serverless-offline": "^8.2.0",
+    "serverless-offline-ssm": "^5.2.0",
     "ts-jest": "^27.0.7",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "deploy": "sls deploy",
     "lint": "eslint . --ext ts,js --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
+    "typecheck": "tsc",
+    "sls-config-check": "sls print",
     "test": "jest"
   },
   "engines": {

--- a/serverless.ts
+++ b/serverless.ts
@@ -58,15 +58,15 @@ const serverlessConfiguration = async (): Promise<AWS> => {
       "serverless-offline": {
         allowCache: true,
       },
-      customDomain : {
+      customDomain: {
         domainName: process.env.DOMAIN_NAME,
         certificateName: process.env.DOMAIN_NAME,
-        basePath: '',
+        basePath: "",
         stage: STAGE,
         createRoute53Record: false,
-        endpointType: 'regional',
-        autoDomain: true
-      }
+        endpointType: "regional",
+        autoDomain: true,
+      },
     },
     useDotenv: true,
   };

--- a/src/libs/lambda.ts
+++ b/src/libs/lambda.ts
@@ -3,5 +3,5 @@ import cors from "@middy/http-cors";
 import middyJsonBodyParser from "@middy/http-json-body-parser";
 
 export const middyfy = (handler) => {
-  return middy(handler).use(middyJsonBodyParser()).use(cors());
+  return middy(handler).use([middyJsonBodyParser(), cors()]);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "noEmit": true,
+    "skipLibCheck": true,
     "target": "ES2020",
     "outDir": "lib"
   },


### PR DESCRIPTION
**What does this PR do?**
- Load environment variables from SSM
- Provide local support using `serverless-offline-ssm`
- Update `README.md` and `.env.example` for env var instructions
- Add `typecheck` and `sls-config-check` scripts

**Tasks**

- [ ] Add the 3 parameters to SSM (staging and production)