### PR TITLE
fix: resolver issue on ropsten network

### DIFF
--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -52,9 +52,7 @@ const customCache: DIDCache = async (parsed, resolve) => {
 };
 
 const provider = INFURA_API_KEY ? new providers.InfuraProvider(NETWORK_NAME, INFURA_API_KEY) : undefined;
-const ethrDidResolver = INFURA_API_KEY
-  ? getResolver({ name: NETWORK_NAME, rpcUrl: `https://${NETWORK_NAME}.infura.io/v3/${INFURA_API_KEY}` })
-  : undefined;
+const ethrDidResolver = INFURA_API_KEY ? getResolver({ infuraProjectId: INFURA_API_KEY }) : undefined;
 const resolver = INFURA_API_KEY ? new Resolver(ethrDidResolver, { cache: customCache }) : undefined;
 
 export const isWhitelisted = (identity: string): boolean => {


### PR DESCRIPTION
## Context

For some reason, specifying the `name` and `rpcUrl` manually does not work when resolving against the `ropsten` network. But `mainnet` works fine.

```javascript
getResolver({ name: NETWORK_NAME, rpcUrl: `https://${NETWORK_NAME}.infura.io/v3/${INFURA_API_KEY}` })
```

**Fragments**:
```javascript
[
  {
    "name": "OpenAttestationDidSignedDocumentStatus",
    "type": "DOCUMENT_STATUS",
    "data": {
      "code": 4,
      "codeString": "KEY_NOT_IN_DID"
    },
    "reason": {
      "message": "No public key found on DID document for the DID did:ethr:0xBF44F2a91612Fb31DB6e781FE5eEbED6bD26cB76 and key did:ethr:0xBF44F2a91612Fb31DB6e781FE5eEbED6bD26cB76#controller",
      "code": 4,
      "codeString": "KEY_NOT_IN_DID"
    },
    "status": "ERROR"
  },
  // ...
]

```

## The Fix (Wierdly)

Just specify the `infuraProjectId`.

```javascript
getResolver({ infuraProjectId: INFURA_API_KEY })
```