### PR TITLE
feat: provider and resolver fallback to alchemy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 /serverless/api-verify-gov-sg/NETWORK_NAME=mainnet
 /serverless/api-verify-gov-sg/INFURA_API_KEY=somekey
+/serverless/api-verify-gov-sg/ALCHEMY_API_KEY=somekey
 /serverless/api-verify-gov-sg/WHITELISTED_ISSUERS=gov.sg,openattestation.com

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To run locally, ensure the required environment variables are set in `.env`. Ref
 ```text
 /serverless/api-verify-gov-sg/NETWORK_NAME=mainnet
 /serverless/api-verify-gov-sg/INFURA_API_KEY=somekey
+/serverless/api-verify-gov-sg/ALCHEMY_API_KEY=somekey
 /serverless/api-verify-gov-sg/WHITELISTED_ISSUERS=gov.sg,openattestation.com
 ```
 

--- a/serverless.ts
+++ b/serverless.ts
@@ -35,6 +35,7 @@ const serverlessConfiguration = async (): Promise<AWS> => {
         STAGE,
         NETWORK_NAME: "${ssm:/serverless/api-verify-gov-sg/NETWORK_NAME}",
         INFURA_API_KEY: "${ssm:/serverless/api-verify-gov-sg/INFURA_API_KEY~true}",
+        ALCHEMY_API_KEY: "${ssm:/serverless/api-verify-gov-sg/ALCHEMY_API_KEY~true}",
         WHITELISTED_ISSUERS: "${ssm:/serverless/api-verify-gov-sg/WHITELISTED_ISSUERS}",
       },
       lambdaHashingVersion: "20201221",

--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -152,15 +152,22 @@ const getVerifier = () => {
       resolvers: { networks: [] },
     };
 
+    /**
+     * 1. Infura - Provider Priority: 1, Resolver Index: 1
+     * 2. Alchemy - Provider Priority: 2, Resolver Index: 0
+     *
+     * Provider: Lower-value priorities are favoured: https://docs.ethers.io/v5/api/providers/other/#FallbackProviderConfig
+     * Resolver: Infura resolver should be last item in array so that it will be used first
+     */
     if (INFURA_API_KEY) {
       const infuraProvider = new providers.InfuraProvider(NETWORK_NAME, INFURA_API_KEY);
       config.providers.push({ provider: infuraProvider, priority: 1 });
-      config.resolvers.networks.push({ name: NETWORK_NAME, provider: infuraProvider });
+      config.resolvers.networks.unshift({ name: NETWORK_NAME, provider: infuraProvider });
     }
     if (ALCHEMY_API_KEY) {
       const alchemyProvider = new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY);
       config.providers.push({ provider: new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY), priority: 2 });
-      config.resolvers.networks.push({ name: NETWORK_NAME, provider: alchemyProvider });
+      config.resolvers.networks.unshift({ name: NETWORK_NAME, provider: alchemyProvider });
     }
 
     const provider = config.providers.length > 0 ? new providers.FallbackProvider(config.providers) : undefined;

--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -139,7 +139,7 @@ const customCache: DIDCache = async (parsed, resolve) => {
   return doc;
 };
 
-let verify: typeof defaultVerify = undefined;
+let verify: typeof defaultVerify;
 
 /**
  * Returns a cached instance of `verify()` that was only instantiated once
@@ -147,7 +147,7 @@ let verify: typeof defaultVerify = undefined;
  */
 const getVerifier = () => {
   if (!verify) {
-    let config: { providers: providers.FallbackProviderConfig[]; resolvers: MultiProviderConfiguration } = {
+    const config: { providers: providers.FallbackProviderConfig[]; resolvers: MultiProviderConfiguration } = {
       providers: [],
       resolvers: { networks: [] },
     };


### PR DESCRIPTION
**What does this PR do?**
- Implement fallback to Alchemy for both Provider and Resolver (tested on local machine by blocking network calls to `https://mainnet.infura.io`)
  - Infura (Priority: `1`)
  - Alchemy (Priority: `2`)
  - Lower-value priorities are favoured: https://docs.ethers.io/v5/api/providers/other/#FallbackProviderConfig
- Refactor for better code readability