### PR TITLE
fix: resolver for both mainnet and ropsten networks

### DIFF
--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -162,12 +162,14 @@ const getVerifier = () => {
     if (INFURA_API_KEY) {
       const infuraProvider = new providers.InfuraProvider(NETWORK_NAME, INFURA_API_KEY);
       config.providers.push({ provider: infuraProvider, priority: 1 });
-      config.resolvers.networks.unshift({ name: NETWORK_NAME, provider: infuraProvider });
+      config.resolvers.networks.unshift({ name: "ropsten", provider: infuraProvider });
+      config.resolvers.networks.unshift({ name: "mainnet", provider: infuraProvider });
     }
     if (ALCHEMY_API_KEY) {
       const alchemyProvider = new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY);
       config.providers.push({ provider: new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY), priority: 2 });
-      config.resolvers.networks.unshift({ name: NETWORK_NAME, provider: alchemyProvider });
+      config.resolvers.networks.unshift({ name: "ropsten", provider: alchemyProvider });
+      config.resolvers.networks.unshift({ name: "mainnet", provider: alchemyProvider });
     }
 
     const provider = config.providers.length > 0 ? new providers.FallbackProvider(config.providers) : undefined;


### PR DESCRIPTION
**What does this PR do?**
Resolve against both `mainnet` and `ropsten` networks

*This is in line with previous behaviour: https://github.com/Open-Attestation/api.verify.gov.sg/commit/b6d244f11af13e9386661952fdd7c6e4a0f1a961