### PR TITLE
fix: increase timeout for infura provider

### DIFF
--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -167,7 +167,7 @@ const getVerifier = () => {
     }
     if (ALCHEMY_API_KEY) {
       const alchemyProvider = new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY);
-      config.providers.push({ provider: new providers.AlchemyProvider(NETWORK_NAME, ALCHEMY_API_KEY), priority: 2 });
+      config.providers.push({ provider: alchemyProvider, priority: 2 });
       config.resolvers.networks.unshift({ name: "ropsten", provider: alchemyProvider });
       config.resolvers.networks.unshift({ name: "mainnet", provider: alchemyProvider });
     }

--- a/src/libs/oa-verify.ts
+++ b/src/libs/oa-verify.ts
@@ -161,7 +161,7 @@ const getVerifier = () => {
      */
     if (INFURA_API_KEY) {
       const infuraProvider = new providers.InfuraProvider(NETWORK_NAME, INFURA_API_KEY);
-      config.providers.push({ provider: infuraProvider, priority: 1 });
+      config.providers.push({ provider: infuraProvider, priority: 1, stallTimeout: 4000 });
       config.resolvers.networks.unshift({ name: "ropsten", provider: infuraProvider });
       config.resolvers.networks.unshift({ name: "mainnet", provider: infuraProvider });
     }


### PR DESCRIPTION
## Context
It was noticed that in a fallback provider, the Alchemy provider was being used quite extensively even though Infura is working well (i.e. no downtime) and Alchemy's priority is set to `2` (lower number is favoured).

## Findings
- The [default timeout](https://github.com/ethers-io/ethers.js/blob/8b62aeff9cce44cbd16ff41f8fc01ebb101f8265/packages/providers/src.ts/fallback-provider.ts#L419) is about 750ms.
- Unfortunately, Infura's response is not that fast (esp when the request is coming from AWS).
- Funny I couldn't replicate this behaviour in my local machine because Infura responds pretty fast to me on my network/laptop.

## The Fix
- Increase the timeout for Infura provider to 4000ms.
- Looking at the Alchemy dashboard, there is no longer any usage for the staging key.